### PR TITLE
Add panel option to test/debug specific file instead of the current file

### DIFF
--- a/lib/delve.js
+++ b/lib/delve.js
@@ -26,7 +26,17 @@ function addOutputMessage(messageType, message) {
 }
 
 function run(file, method) {
-	const { path: dlvPath, args } = store.getState().delve;
+	const { path: dlvPath, args, fileOverride } = store.getState().delve;
+
+	let trimmedFile = fileOverride.trim();
+	if (fileOverride && trimmedFile.trim !== "") {
+		if (path.isAbsolute(trimmedFile)) {
+		    file = trimmedFile
+		} else {
+		    file = atom.project.resolvePath(trimmedFile);
+		}
+	}
+
 	if (!dlvPath || dlvProcess || !file) {
 		return;
 	}

--- a/lib/panel.jsx
+++ b/lib/panel.jsx
@@ -68,6 +68,10 @@ class Panel extends React.Component {
 		return <div>
 			<input className="go-debug-panel-args native-key-bindings" value={this.props.args}
 				placeholder="arguments passed to delve after --" onChange={this.props.onArgsChange} />
+
+			<input className="go-debug-panel-args native-key-bindings" value={this.props.fileOverride}
+				placeholder="Insert a file to run instead of the current file (relative to project root)" onChange={this.props.onFileOverrideChange} />
+
 		</div>;
 	}
 
@@ -244,7 +248,8 @@ const PanelListener = connect(
 			goroutines: state.delve.goroutines,
 			breakpoints: state.delve.breakpoints,
 			selectedStacktrace: state.delve.selectedStacktrace,
-			selectedGoroutine: state.delve.selectedGoroutine
+			selectedGoroutine: state.delve.selectedGoroutine,
+			fileOverride: state.delve.fileOverride
 		};
 	},
 	(dispatch) => {
@@ -257,6 +262,9 @@ const PanelListener = connect(
 			},
 			onArgsChange: (ev) => {
 				dispatch({ type: "UPDATE_ARGS", args: ev.target.value });
+			},
+			onFileOverrideChange: (ev) => {
+				dispatch({ type: "UPDATE_FILE_OVERRIDE", fileOverride: ev.target.value });
 			}
 		};
 	}

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,7 +1,6 @@
 "use babel";
 
 import { createStore, combineReducers } from "redux";
-
 const assign = (...items) => Object.assign.apply(Object, [{}].concat(items));
 
 function updateArrayItem(array, index, o) {
@@ -141,6 +140,13 @@ function path(state = "", action) {
 	return state;
 }
 
+function fileOverride(state = "", action) {
+	if (action.type === "UPDATE_FILE_OVERRIDE") {
+		return action.fileOverride;
+	}
+	return state;
+}
+
 const delve = combineReducers({
 	stacktrace,
 	goroutines,
@@ -149,6 +155,7 @@ const delve = combineReducers({
 	selectedStacktrace,
 	selectedGoroutine,
 	args,
+	fileOverride,
 	path
 });
 
@@ -238,7 +245,8 @@ export function serialize() {
 		panel: state.panel,
 		delve: {
 			breakpoints: state.delve.breakpoints.map(({ file, line }) => { return { file, line }; }),
-			args: state.delve.args
+			args: state.delve.args,
+			fileOverride: state.delve.fileOverride
 		}
 	};
 }


### PR DESCRIPTION
Hey,

I find when working on larger projects locally, I want to either test specific files, or simply start a debug session from my main file (typically main.go).  I've been navigating back to main.go prior to starting debug sessions, but that was getting a bit tedious.  I added a text box below the addition options text box that allows you to override which file go-debug will use for testing/debug.

Let me know what you think, or if you want something changed!

Rob