### PR TITLE
Automatically start the debug session when test or debug is pressed

### DIFF
--- a/lib/delve.js
+++ b/lib/delve.js
@@ -73,9 +73,12 @@ function run(file, method) {
 				dlvConnection = conn;
 				addOutputMessage("delve", `Started delve with "${file}" with "${method}"`);
 				store.dispatch({ type: "SET_STATE", state: "started" });
-
-				getBreakpoints().forEach((bp) => {
-					addBreakpoint(bp.file, bp.line);
+				Promise.all(
+					getBreakpoints().map((bp) => {
+						return addBreakpoint(bp.file, bp.line);
+					})
+				).then(() => {
+					command("continue");
 				});
 			});
 		}


### PR DESCRIPTION
After the debug or test session is started, dlv requires that you all `continue` to start to session.  I find it pretty useful to automatically trigger the continue operation (we go from two button clicks two one per each test / debug cycle).