### PR TITLE
Add log output to display the CWD of the delve process

### DIFF
--- a/lib/delve-connection.js
+++ b/lib/delve-connection.js
@@ -62,6 +62,7 @@ export default class DelveConnection {
       }
 
       const start = ({ dlvArgs, cwd, env }) => {
+        this._addOutputMessage('Starting delve with cwd ' + cwd + '\n')
         proc = this._spawn(dlvArgs, { cwd, env })
 
         proc.stderr.on('data', (chunk) => {


### PR DESCRIPTION
This aids debugging of custom configurations which have overridden the "cwd" parameter.