### PR TITLE
Fix for compatibility with go-plus 5.7+

### DIFF
--- a/lib/delve-get.js
+++ b/lib/delve-get.js
@@ -28,7 +28,8 @@ export default function getDelve (goget, goconfig) {
   }
 
   function getVersion (dlvPath) {
-    return goconfig.executor.exec(dlvPath, ['version'], 'project').then((r) => {
+    const options = goconfig.executor.getOptions('project')
+    return goconfig.executor.exec(dlvPath, ['version'], options).then((r) => {
       if (r.exitcode !== 0) {
         const message = `Failed to get version of dlv:\n  ` +
           `Exit code: ${r.exitcode}\n  ` +


### PR DESCRIPTION
exec() now takes an options object instead of an object or a string.

Fixes https://github.com/joefitzgerald/go-plus/issues/726