### PR TITLE
Expose dlv's `--backend` arg in config

### DIFF
--- a/lib/delve-connection.js
+++ b/lib/delve-connection.js
@@ -172,7 +172,7 @@ function hostAndPort (config) {
   return { host, port }
 }
 
-function getDlvArgs (config, variables, ) {
+function getDlvArgs (config, variables) {
   const { mode, program, showLog = false, buildFlags, backend = "default", init: dlvInit, args } = config
   const { host, port } = hostAndPort(config)
   const dlvArgs = [mode || 'debug']

--- a/lib/delve-connection.js
+++ b/lib/delve-connection.js
@@ -186,7 +186,7 @@ function getDlvArgs (config, variables, ) {
 
   let possibleBackendValues = ['default', 'native', 'lldb', 'rr']
   if(!possibleBackendValues.includes(backend)) {
-    return Promise.reject(new Error(`backend must be one of these values ${possibleBackendValues.join(', ')}`));
+    return Promise.reject(new Error(`--backend must be one of these values ${possibleBackendValues.join(', ')}`));
   }
 
   return prom.then(() => {

--- a/lib/delve-connection.js
+++ b/lib/delve-connection.js
@@ -58,7 +58,7 @@ export default class DelveConnection {
             cwd,
             env: variables.env
           }
-        })
+        }).catch(reject)
       }
 
       const spawn = ({ dlvArgs, cwd, env }) => {
@@ -172,8 +172,8 @@ function hostAndPort (config) {
   return { host, port }
 }
 
-function getDlvArgs (config, variables) {
-  const { mode, program, showLog = false, buildFlags, init: dlvInit, args } = config
+function getDlvArgs (config, variables, ) {
+  const { mode, program, showLog = false, buildFlags, backend = "default", init: dlvInit, args } = config
   const { host, port } = hostAndPort(config)
   const dlvArgs = [mode || 'debug']
 
@@ -184,15 +184,22 @@ function getDlvArgs (config, variables) {
     })
   }
 
+  let possibleBackendValues = ['default', 'native', 'lldb', 'rr']
+  if(!possibleBackendValues.includes(backend)) {
+    return Promise.reject(new Error(`backend must be one of these values ${possibleBackendValues.join(', ')}`));
+  }
+
   return prom.then(() => {
     if (mode === 'exec') {
       // debug a pre compiled executable
       dlvArgs.push(replaceVariable(program, variables))
     }
+
     dlvArgs.push(
       '--headless=true',
       `--listen=${host}:${port}`,
-      '--api-version=2'
+      '--api-version=2',
+      `--backend=${backend}`
     )
     if (showLog) {
       // turn additional delve logging on or off

--- a/lib/delve-connection.js
+++ b/lib/delve-connection.js
@@ -173,7 +173,7 @@ function hostAndPort (config) {
 }
 
 function getDlvArgs (config, variables) {
-  const { mode, program, showLog = false, buildFlags, backend = "default", init: dlvInit, args } = config
+  const { mode, program, showLog = false, buildFlags, backend = 'default', init: dlvInit, args } = config
   const { host, port } = hostAndPort(config)
   const dlvArgs = [mode || 'debug']
 
@@ -185,7 +185,7 @@ function getDlvArgs (config, variables) {
   }
 
   let possibleBackendValues = ['default', 'native', 'lldb', 'rr']
-  if(!possibleBackendValues.includes(backend)) {
+  if (!possibleBackendValues.includes(backend)) {
     return Promise.reject(new Error(`--backend must be one of these values ${possibleBackendValues.join(', ')}`));
   }
 


### PR DESCRIPTION
https://github.com/derekparker/delve/issues/817

There seems to be an issue using `lldb` as a debugger option. I was able to resolve the issue by changing it to `--backend=native`. To allow more flexibility and unblock atom go-debug users who are experiencing this issue, I suggest that we expose the `--backend` in config while maintaing a default value of `--backend=default`.

- [x] Tested locally
- [x] Ran it with expected + unexpected args