### PR TITLE
Add accept-multiclient to default arguments

### DIFF
--- a/lib/delve-connection.js
+++ b/lib/delve-connection.js
@@ -199,7 +199,8 @@ function getDlvArgs (config, variables) {
       '--headless=true',
       `--listen=${host}:${port}`,
       '--api-version=2',
-      `--backend=${backend}`
+      `--backend=${backend}`,
+      `--accept-multiclient`
     )
     if (showLog) {
       // turn additional delve logging on or off


### PR DESCRIPTION
This allows connecting to dlv server to run
arbitrary commands while dlv is running.